### PR TITLE
Add support for Postgres metadata storage in AWS with RDS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,31 @@ To run it, you need to create a `tfvars` file that includes the required Terrafo
 See below for the required variables. There is a README for each module with more details on the
 variables that can be set.
 
+The install script relies on the following dependencies:
+
+* [Terraform](https://developer.hashicorp.com/terraform/install)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/)
+* [Helm](https://helm.sh/docs/intro/install/)
+
+For AWS with Postgres:
+
+* [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
+* [jq](https://jqlang.org/download/)
+
 Note that you'll also need to include a provider under the folder of the desired cloud.
 
 Required environment variables:
 
-| Variable          | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| BUFSTREAM_KEYFILE | Path to file containing Bufstream base64 encoded key from Buf |
-| BUFSTREAM_VERSION | The version of Bufstream to deploy                            |
-| BUFSTREAM_CLOUD   | Which cloud to deploy to. Must be `aws` or `gcp`              |
-| BUFSTREAM_TFVARS  | Path to the `tfvars` file                                     |
+| Variable            | Description                                                              |
+| -----------------   | ------------------------------------------------------------------------ |
+| BUFSTREAM_KEYFILE   | Path to file containing Bufstream base64 encoded key from Buf            |
+| BUFSTREAM_VERSION   | The version of Bufstream to deploy                                       |
+| BUFSTREAM_CLOUD     | Which cloud to deploy to. Must be `aws` or `gcp`                         |
+| BUFSTREAM_TFVARS    | Path to the `tfvars` file                                                |
+| BUFSTREAM_METADATA  | Which database to use for metadata storage. Must be `etcd` or `postgres` |
+
+> [!WARNING]
+> Postgres is only supported in AWS at this time.
 
 Example of running the install script, you will need to replace the `<latest-version>` string with the version of Bufstream you are planning to deploy:
 
@@ -33,6 +48,7 @@ BUFSTREAM_KEYFILE=$PWD/keyfile \
 BUFSTREAM_VERSION= <latest-version> \
 BUFSTREAM_CLOUD=gcp \
 BUFSTREAM_TFVARS=$PWD/bufstream.tfvars \
+BUFSTREAM_METADATA=postgres \
 install.sh
 ```
 
@@ -50,6 +66,8 @@ kubectl --kubeconfig gen/kubeconfig get pods -n bufstream
 By default, the module creates all resources necessary to deploy an auto mode Kubernetes cluster to the desired
 account. It also creates some specific resources required for Bufstream: an S3 bucket and a role that the
 Bufstream service account can assume to access the bucket using EKS Pod Identity.
+
+If Postgres is selected for the metadata storage, an RDS instance and a Secrets Manager secret for the Postgres user password are also created.
 
 Required variables in `tfvars`:
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -3,21 +3,23 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
 
 ## Providers
 
 | Name | Version |
-|------|--------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.0 |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.99.1 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.3 |
 
 ## Modules
 
-| Name | Source |
-|------|--------|
-| <a name="module_kubernetes"></a> [kubernetes](#module\_kubernetes) | ./kubernetes |
-| <a name="module_network"></a> [network](#module\_network) | ./network |
-| <a name="module_storage"></a> [storage](#module\_storage) | ./storage |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_kubernetes"></a> [kubernetes](#module\_kubernetes) | ./kubernetes | n/a |
+| <a name="module_network"></a> [network](#module\_network) | ./network | n/a |
+| <a name="module_postgres"></a> [postgres](#module\_postgres) | ./metadata/postgres | n/a |
+| <a name="module_storage"></a> [storage](#module\_storage) | ./storage | n/a |
 
 ## Resources
 
@@ -26,14 +28,16 @@
 | [aws_lb.bufstream](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_security_group.bufstream-nlb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [local_file.bufstream_values](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.context](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.pg_secret_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of bucket, must be globally unique | `string` | n/a | yes |
+| <a name="input_bufstream_k8s_namespace"></a> [bufstream\_k8s\_namespace](#input\_bufstream\_k8s\_namespace) | Namespace which bufstream will be installed. | `string` | `"bufstream"` | no |
+| <a name="input_bufstream_metadata"></a> [bufstream\_metadata](#input\_bufstream\_metadata) | DB type for Bufstream metadata | `string` | n/a | yes |
 | <a name="input_bufstream_service_account"></a> [bufstream\_service\_account](#input\_bufstream\_service\_account) | Service account name for bufstream. | `string` | `"bufstream-service-account"` | no |
 | <a name="input_cluster_endpoint_public_access"></a> [cluster\_endpoint\_public\_access](#input\_cluster\_endpoint\_public\_access) | Allow public access to cluster API endpoint. | `string` | `true` | no |
 | <a name="input_create_igw"></a> [create\_igw](#input\_create\_igw) | Create an Internet Gateway. | `bool` | `true` | no |
@@ -44,7 +48,15 @@
 | <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | Name of the EKS cluster. | `string` | `"bufstream-1"` | no |
 | <a name="input_eks_cluster_version"></a> [eks\_cluster\_version](#input\_eks\_cluster\_version) | Version of the EKS cluster. | `string` | `"1.31"` | no |
 | <a name="input_generate_config_files_path"></a> [generate\_config\_files\_path](#input\_generate\_config\_files\_path) | If present, generate config files for bufstream values, kubeconfig and the context name at the selected path. | `string` | `null` | no |
+| <a name="input_postgres_db_name"></a> [postgres\_db\_name](#input\_postgres\_db\_name) | Name of the database for metadata | `string` | `"bufstream"` | no |
+| <a name="input_postgres_password"></a> [postgres\_password](#input\_postgres\_password) | Postgres password for RDS instance | `string` | `null` | no |
+| <a name="input_postgres_username"></a> [postgres\_username](#input\_postgres\_username) | Postgres username for RDS instance | `string` | `"postgres"` | no |
+| <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | Postgres version | `string` | `"17"` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | AWS profile for provider. | `string` | n/a | yes |
+| <a name="input_rds_allocated_storage"></a> [rds\_allocated\_storage](#input\_rds\_allocated\_storage) | Allocated storage for RDS | `number` | `20` | no |
+| <a name="input_rds_identifier"></a> [rds\_identifier](#input\_rds\_identifier) | Identifier of the RDS instance | `string` | `null` | no |
+| <a name="input_rds_instance_class"></a> [rds\_instance\_class](#input\_rds\_instance\_class) | RDS instance class to use | `string` | `"db.c6gd.xlarge"` | no |
+| <a name="input_rds_port"></a> [rds\_port](#input\_rds\_port) | Port number for the RDS instance | `number` | `5432` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region to deploy to. | `string` | `"us-west-2"` | no |
 | <a name="input_s3_vpc_endpoint"></a> [s3\_vpc\_endpoint](#input\_s3\_vpc\_endpoint) | Optional endpoint for s3 in your region. | `string` | `null` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Optional IDs of the private subnets for the EKS cluster to use. | `list(string)` | `[]` | no |
@@ -52,7 +64,6 @@
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR range for the VPC, needs to be able to contain six contiguous /21 subnets. | `string` | `"10.64.0.0/16"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of VPC to use, required if `create_vpc` is `false` | `string` | `""` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC to create. | `string` | `"bufstream-vpc-1"` | no |
-| <a name="input_bufstream_k8s_namespace"></a> [bufstream\_k8s\_namespace](#input\_wif\_bufstream\_k8s\_namespace) | Namespace in which bufstream will be installed. | `string` | `"bufstream"` | no |
 
 ## Outputs
 

--- a/aws/bufstream.yaml.tpl
+++ b/aws/bufstream.yaml.tpl
@@ -24,8 +24,15 @@ kafka:
     port: 9092
 %{ endif ~}
 metadata:
+%{ if metadata == "etcd" ~}
   use: etcd
   etcd:
     addresses:
     - host: "bufstream-etcd.bufstream.svc.cluster.local"
       port: 2379
+%{ endif ~}
+%{ if metadata == "postgres" ~}
+  use: postgres
+  postgres:
+    secretName: bufstream-postgres
+%{ endif ~}

--- a/aws/metadata/postgres/main.tf
+++ b/aws/metadata/postgres/main.tf
@@ -1,0 +1,56 @@
+data "aws_vpc" "buf" {
+  id = var.vpc_id
+}
+
+resource "aws_security_group" "rds" {
+  name   = "${local.identifier}-rds-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = var.rds_port
+    to_port     = var.rds_port
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.buf.cidr_block]
+  }
+
+}
+
+variable "rds_identifier" {
+  description = "Identifier of the RDS instance"
+  type        = string
+  default     = null
+}
+
+resource "random_string" "rds_identifier" {
+  length  = 16
+  special = false
+  numeric = false
+}
+
+locals {
+  identifier = var.rds_identifier != null ? var.rds_identifier : random_string.rds_identifier.result
+}
+
+resource "aws_db_subnet_group" "rds" {
+  name       = "${local.identifier}-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${local.identifier}-subnet-group"
+  }
+}
+
+resource "aws_db_instance" "bufpg" {
+  engine                      = "postgres"
+  engine_version              = var.postgres_version
+  username                    = var.postgres_username
+  manage_master_user_password = true
+  allocated_storage           = var.rds_allocated_storage
+  port                        = var.rds_port
+  instance_class              = var.rds_instance_class
+  db_name                     = var.postgres_db_name
+  skip_final_snapshot         = true
+
+  db_subnet_group_name   = aws_db_subnet_group.rds.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+}

--- a/aws/metadata/postgres/outputs.tf
+++ b/aws/metadata/postgres/outputs.tf
@@ -1,0 +1,12 @@
+output "pg_dsn" {
+  description = "Partial DSN of the Postgres instance with env placeholder for password"
+
+  value = "postgresql://${aws_db_instance.bufpg.username}:$PG_PASSWORD@${aws_db_instance.bufpg.endpoint}/${aws_db_instance.bufpg.db_name}?sslmode=require"
+
+  sensitive = true
+}
+
+output "pg_pw_secret_arn" {
+  description = "The ARN of the secret holding the PG password"
+  value       = aws_db_instance.bufpg.master_user_secret[0].secret_arn
+}

--- a/aws/metadata/postgres/variables.tf
+++ b/aws/metadata/postgres/variables.tf
@@ -1,0 +1,47 @@
+variable "vpc_id" {
+  description = "VPC ID of the EKS cluster"
+  type        = string
+}
+
+variable "postgres_username" {
+  description = "Postgres username for RDS instance"
+  type        = string
+  default     = "postgres"
+}
+
+variable "subnet_ids" {
+  description = "IDs of the private subnets for the RDS instance to use"
+  type        = list(string)
+}
+
+variable "rds_port" {
+  description = "Port number for the RDS instance"
+  type        = number
+  default     = 5432
+}
+
+# Default values from
+# https://buf.build/docs/bufstream/deployment/aws/deploy-postgres/#create-an-rds-for-postgresql-instance
+variable "rds_instance_class" {
+  description = "RDS instance class to use"
+  type        = string
+  default     = "db.c6gd.xlarge"
+}
+
+variable "postgres_version" {
+  description = "Postgres version"
+  type        = string
+  default     = "17"
+}
+
+variable "rds_allocated_storage" {
+  description = "Allocated storage for RDS"
+  type        = number
+  default     = 20
+}
+
+variable "postgres_db_name" {
+  description = "Name of the database for metadata"
+  type        = string
+  default     = "bufstream"
+}

--- a/aws/pg-setup.sh.tpl
+++ b/aws/pg-setup.sh.tpl
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+PG_PASSWORD=$(
+  aws secretsmanager get-secret-value \
+    --secret-id="${secret_arn}" \
+    --query SecretString \
+    --output text |
+    jq '.password' -r |
+    awk '{printf "%s", $0}' | jq -sRr @uri
+)
+
+manifest=$(
+  cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bufstream-postgres
+  namespace:  "$NAMESPACE"
+type: Opaque,
+stringData: 
+  dsn: "${dsn}"
+EOF
+)
+
+echo "$manifest" | kubectl apply -f - \
+  --kubeconfig "$KUBECONFIG" \
+  --namespace "$NAMESPACE"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -9,6 +9,17 @@ variable "profile" {
   type        = string
 }
 
+variable "bufstream_metadata" {
+  description = "DB type for Bufstream metadata"
+  type        = string
+
+  validation {
+    condition = contains(["postgres", "etcd"], var.bufstream_metadata)
+
+    error_message = "must be either 'postgres' or 'etcd'"
+  }
+}
+
 # Networking vars
 
 variable "create_vpc" {
@@ -120,4 +131,55 @@ variable "generate_config_files_path" {
   description = "If present, generate config files for bufstream values, kubeconfig and the context name at the selected path."
   type        = string
   default     = null
+}
+
+# Metadata vars
+
+variable "postgres_username" {
+  description = "Postgres username for RDS instance"
+  type        = string
+  default     = "postgres"
+}
+
+variable "postgres_password" {
+  description = "Postgres password for RDS instance"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "rds_identifier" {
+  description = "Identifier of the RDS instance"
+  type        = string
+  default     = null
+}
+
+variable "rds_port" {
+  description = "Port number for the RDS instance"
+  type        = number
+  default     = 5432
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class to use"
+  type        = string
+  default     = "db.c6gd.xlarge"
+}
+
+variable "postgres_version" {
+  description = "Postgres version"
+  type        = string
+  default     = "17"
+}
+
+variable "rds_allocated_storage" {
+  description = "Allocated storage for RDS"
+  type        = number
+  default     = 20
+}
+
+variable "postgres_db_name" {
+  description = "Name of the database for metadata"
+  type        = string
+  default     = "bufstream"
 }


### PR DESCRIPTION
Adding option to deploy Bufstream in AWS with PostgreSQL as the metadata storage. The `metadata` module provisions an RDS instance.

If using the script or running with the option to generate configs, Terraform will create the necessary Kubernetes secret for Bufstream to access the Postgres database.
