### PR TITLE
AWS Postgres fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Use it to inspect the deployment or for troubleshooting.
 
 ```bash
 # Assuming the namespace Bufstream was deployed to is "bufstream"
-kubectl --kubeconfig gen/kubeconfig get pods -n bufstream
+kubectl --kubeconfig gen/kubeconfig.yaml get pods -n bufstream
 ```
 
 ## AWS

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -102,8 +102,10 @@ locals {
   })
 
   pg_secret = local.create_pg ? templatefile("${path.module}/pg-setup.sh.tpl", {
-    secret_arn = module.postgres[0].pg_pw_secret_arn
-    dsn        = module.postgres[0].pg_dsn
+    region              = var.region
+    secret_arn          = module.postgres[0].pg_pw_secret_arn
+    dsn                 = module.postgres[0].pg_dsn
+    aws_profile         = var.profile
   }) : null
 }
 

--- a/aws/metadata/postgres/main.tf
+++ b/aws/metadata/postgres/main.tf
@@ -25,6 +25,7 @@ resource "random_string" "rds_identifier" {
   length  = 16
   special = false
   numeric = false
+  upper   = false
 }
 
 locals {

--- a/aws/pg-setup.sh.tpl
+++ b/aws/pg-setup.sh.tpl
@@ -2,6 +2,8 @@
 
 PG_PASSWORD=$(
   aws secretsmanager get-secret-value \
+    --profile "${aws_profile}" \
+    --region "${region}" \
     --secret-id="${secret_arn}" \
     --query SecretString \
     --output text |
@@ -17,7 +19,7 @@ metadata:
   name: bufstream-postgres
   namespace:  "$NAMESPACE"
 type: Opaque,
-stringData: 
+stringData:
   dsn: "${dsn}"
 EOF
 )

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,11 @@ cat "${BUFSTREAM_KEYFILE}" | helm registry login -u _json_key_base64 --password-
 pushd "${BUFSTREAM_CLOUD}"
 
 echo "Applying Terraform..."
+ TF_VAR_generate_config_files_path="${CONFIG_GEN_PATH}" \
+  TF_VAR_bufstream_metadata="${BUFSTREAM_METADATA}" \
+  terraform init \
+  --var-file "${BUFSTREAM_TFVARS}" \
+  --var "bufstream_k8s_namespace=${BUFSTREAM_NAMESPACE:-bufstream}"
 
  TF_VAR_generate_config_files_path="${CONFIG_GEN_PATH}" \
   TF_VAR_bufstream_metadata="${BUFSTREAM_METADATA}" \


### PR DESCRIPTION
- Ensure we terraform init in the install.sh script, as otherwise the first run of this will fail and require customers to cd into dirs manually.
- Ensure random_string doesn't produce invalid name for the rg subnet group (no uppercase characters allowed)
- Use profile/region explicitly for the pg-setup.sh script when interacting with the AWS cli, to match our kubeconfig behaviour
- Fix README reference to kubeconfig