### PR TITLE
Clean up docs and GCP postgres setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ Note that you'll also need to include a provider under the folder of the desired
 
 Required environment variables:
 
-| Variable            | Description                                                              |
-| -----------------   | ------------------------------------------------------------------------ |
-| BUFSTREAM_VERSION   | The version of Bufstream to deploy                                       |
-| BUFSTREAM_CLOUD     | Which cloud to deploy to. Must be `aws` or `gcp`                         |
-| BUFSTREAM_TFVARS    | Path to the `tfvars` file                                                |
-| BUFSTREAM_METADATA  | Which database to use for metadata storage. Must be `etcd` or `postgres` |
+| Variable            | Description                                                                 |
+| -----------------   | --------------------------------------------------------------------------- |
+| BUFSTREAM_VERSION   | The version of Bufstream to deploy                                          |
+| BUFSTREAM_CLOUD     | Which cloud to deploy to. Must be `aws` or `gcp`                            |
+| BUFSTREAM_TFVARS    | Path to the `tfvars` file                                                   |
+| BUFSTREAM_METADATA  | Which database to use for metadata storage. Must be `etcd` or `postgres`    |
+| BUFSTREAM_NAMESPACE | Namespace for bufstream. Required ONLY if not usig the `bufstream` default. |
 
 Example of running the install script, you will need to replace the `<latest-version>` string with the version of Bufstream you are planning to deploy:
 

--- a/gcp/metadata/postgres/main.tf
+++ b/gcp/metadata/postgres/main.tf
@@ -5,10 +5,6 @@ resource "random_string" "instance_name" {
   upper   = false
 }
 
-data "google_service_account" "bufstream_sa" {
-  account_id = var.service_account
-}
-
 locals {
   instance_name = var.instance_name != null ? var.instance_name : random_string.instance_name.result
 }
@@ -17,13 +13,13 @@ locals {
 resource "google_project_iam_member" "cloudsql_client_role" {
   project = var.project_id
   role    = "roles/cloudsql.client"
-  member  = data.google_service_account.bufstream_sa.member
+  member  = "serviceAccount:${var.service_account}"
 }
 
 resource "google_project_iam_member" "cloudsql_instance_user_role" {
   project = var.project_id
   role    = "roles/cloudsql.instanceUser"
-  member  = data.google_service_account.bufstream_sa.member
+  member  = "serviceAccount:${var.service_account}"
 }
 
 resource "google_sql_database_instance" "bufpg" {
@@ -57,4 +53,3 @@ resource "google_sql_database" "bufdb" {
   project  = var.project_id
   instance = google_sql_database_instance.bufpg.name
 }
-

--- a/gcp/pg-setup.sh.tpl
+++ b/gcp/pg-setup.sh.tpl
@@ -19,13 +19,14 @@ gcloud sql users create ${db_user} \
   --project=${project_id} \
   --instance=${instance_name} \
   --type=cloud_iam_service_account
-  
+
 gcloud storage cp \
   "$sqlfilepath" \
   "gs://${bucket}/$sqlfile" \
   --quiet
-  
+
 gcloud sql import sql \
+  --project=${project_id} \
   "${instance_name}" \
   "gs://${bucket}/$sqlfile" \
   --database ${db_name} \


### PR DESCRIPTION
In some cases, terraform tries to resolve the `data` for service account in the postgres gcp module before it is created to even properly evalue the file, so we stop relying on the data call.