### PR TITLE
Allow force destroy of s3, fix outputs

### DIFF
--- a/aws/storage/main.tf
+++ b/aws/storage/main.tf
@@ -4,8 +4,9 @@ locals {
 }
 
 resource "aws_s3_bucket" "bufstream" {
-  count  = var.create_bucket ? 1 : 0
-  bucket = var.bucket_name
+  count         = var.create_bucket ? 1 : 0
+  bucket        = var.bucket_name
+  force_destroy = var.force_destroy
 }
 
 data "aws_s3_bucket" "bufstream" {

--- a/aws/storage/outputs.tf
+++ b/aws/storage/outputs.tf
@@ -1,3 +1,3 @@
 output "bucket_ref" {
-  value = aws_s3_bucket.bufstream[0].id
+  value = var.create_bucket ? aws_s3_bucket.bufstream[0].id : data.aws_s3_bucket.bufstream[0].id
 }

--- a/aws/storage/variables.tf
+++ b/aws/storage/variables.tf
@@ -13,3 +13,9 @@ variable "bufstream_role" {
   description = "Name of the IRSA role for bufstream."
   type        = string
 }
+
+variable "force_destroy" {
+  description = "Set force destroy on the bucket."
+  type        = string
+  default     = false
+}


### PR DESCRIPTION
The outputs of the s3 module were not happy if you didn't create the bucket and just passed in a name, this should fix that. Also allow to set the `force_destroy` on the bucket for easier clean up.