### PR TITLE
Allow Aurora usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ account. It also creates some specific resources required for Bufstream: an S3 b
 Bufstream service account can assume to access the bucket using EKS Pod Identity.
 
 If Postgres is selected for the metadata storage, an RDS instance and a Secrets Manager secret for the Postgres user password are also created.
+If Aurora is selected for the metadata storage, an AWS Aurora cluster and a Secrets Manager secret for the Postgres user password are also created.
+
+If using Aurora, be aware that it attempts to use a single AZ for provisioned instances. You must provide a valid AZ for the region specified in
+the region variable. Most regions follow the convention of `us-east-1` -> `us-east-1a` for region -> az. This value does not have a default because
+it is different for every region.
 
 Required variables in `tfvars`:
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,8 @@ Bufstream service account can assume to access the bucket using EKS Pod Identity
 If Postgres is selected for the metadata storage, an RDS instance and a Secrets Manager secret for the Postgres user password are also created.
 If Aurora is selected for the metadata storage, an AWS Aurora cluster and a Secrets Manager secret for the Postgres user password are also created.
 
-If using Aurora, be aware that it attempts to use a single AZ for provisioned instances. You must provide a valid AZ for the region specified in
-the region variable. Most regions follow the convention of `us-east-1` -> `us-east-1a` for region -> az. This value does not have a default because
-it is different for every region.
+If using Aurora, be aware that it attempts to use a single AZ for provisioned instances. Most regions follow the convention of `us-east-1` -> `us-east-1a` for region -> az.
+This will default to the first available AZ from the region variable.
 
 Aurora additionally uses the `postgres_username`, `postgres_version` and `postgres_db_name` variables that Postgres uses, which are not required to be set.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ If using Aurora, be aware that it attempts to use a single AZ for provisioned in
 the region variable. Most regions follow the convention of `us-east-1` -> `us-east-1a` for region -> az. This value does not have a default because
 it is different for every region.
 
+Aurora additionally implicitly uses the `postgres_username`, `postgres_version` and `postgres_db_name` variables, which are not required to be set.
+
 Required variables in `tfvars`:
 
 | Variable    | Description                                |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If using Aurora, be aware that it attempts to use a single AZ for provisioned in
 the region variable. Most regions follow the convention of `us-east-1` -> `us-east-1a` for region -> az. This value does not have a default because
 it is different for every region.
 
-Aurora additionally implicitly uses the `postgres_username`, `postgres_version` and `postgres_db_name` variables, which are not required to be set.
+Aurora additionally uses the `postgres_username`, `postgres_version` and `postgres_db_name` variables that Postgres uses, which are not required to be set.
 
 Required variables in `tfvars`:
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -52,6 +52,11 @@
 | <a name="input_postgres_password"></a> [postgres\_password](#input\_postgres\_password) | Postgres password for RDS instance | `string` | `null` | no |
 | <a name="input_postgres_username"></a> [postgres\_username](#input\_postgres\_username) | Postgres username for RDS instance | `string` | `"postgres"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | Postgres version | `string` | `"17"` | no |
+| <a name="input_aurora_identifier"></a> [aurora\_identifier](#input\_aurora\_identifier) | custom Aurora instance identifier | `string` | `null` | no |
+| <a name="input_aurora_port"></a> [aurora\_port](#input\_aurora\_port) | set a custom port for Aurora instances to listen on | `number` | `5432` | no |
+| <a name="input_aurora_instance_class"></a> [aurora\_instance\_class](#input\_aurora\_instance\_class) | instance class to use for Aurora | `string` | `"db.r6gd.xlarge"` | no |
+| <a name="input_availabilty_zone"></a> [availability\_zone](#input\_availability\_zone) | which AZ to use for the aurora instances. required if using Aurora | `string` | `null` | yes |
+| <a name="input_cluster_instance_count"></a> [cluster\_instance\_count](#input\_cluster\_instance\_count) | How many Aurora instances to create | `number` | `2` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | AWS profile for provider. | `string` | n/a | yes |
 | <a name="input_rds_allocated_storage"></a> [rds\_allocated\_storage](#input\_rds\_allocated\_storage) | Allocated storage for RDS | `number` | `20` | no |
 | <a name="input_rds_identifier"></a> [rds\_identifier](#input\_rds\_identifier) | Identifier of the RDS instance | `string` | `null` | no |
@@ -64,7 +69,7 @@
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR range for the VPC, needs to be able to contain six contiguous /21 subnets. AWS suggests a /19 but most will recommend a /16 to avoid IP exhaustion. https://docs.aws.amazon.com/eks/latest/best-practices/ip-opt.html#_mitigate_ip_exhaustion | `string` | `"10.64.0.0/16"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of VPC to use, required if `create_vpc` is `false` | `string` | `""` | no |
 | <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name) | Name of the VPC to create. | `string` | `"bufstream-vpc-1"` | no |
-| <a name="input_vpc_name"></a> [internal\_only\_nlb](#internal\_only\_nlb) | Allows enabling internet-facing load balancer for Bufstream | `bool` | `true` | no |
+| <a name="internal_only_nlb"></a> [internal\_only\_nlb](#internal\_only\_nlb) | Allows enabling internet-facing load balancer for Bufstream | `bool` | `true` | no |
 
 ## Outputs
 

--- a/aws/bufstream.yaml.tpl
+++ b/aws/bufstream.yaml.tpl
@@ -31,7 +31,7 @@ metadata:
     - host: "bufstream-etcd.bufstream.svc.cluster.local"
       port: 2379
 %{ endif ~}
-%{ if metadata == "postgres" ~}
+%{ if metadata == "postgres" || metadata == "aurora" ~}
   use: postgres
   postgres:
     secretName: bufstream-postgres

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -66,6 +66,10 @@ module "postgres" {
   postgres_db_name      = var.postgres_db_name
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "aurora" {
   source = "./metadata/aurora"
   count  = local.create_aurora ? 1 : 0
@@ -78,7 +82,7 @@ module "aurora" {
   aurora_instance_class  = var.aurora_instance_class
   postgres_version       = var.postgres_version
   postgres_db_name       = var.postgres_db_name
-  availability_zone      = var.availability_zone
+  availability_zone      = var.availability_zone == null ? data.aws_availability_zones.available.names[0] : var.availability_zone
   aws_region             = var.region
   cluster_instance_count = var.cluster_instance_count
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -14,6 +14,7 @@ locals {
   cluster_name = var.eks_cluster_name == null ? "bufstream-${local.deploy_id}" : var.eks_cluster_name
   vpc_name     = var.vpc_name == null ? "bufstream-vpc-${local.deploy_id}" : var.vpc_name
   rds_id       = var.rds_identifier == null ? local.deploy_id : var.rds_identifier
+  aurora_id    = var.aurora_identifier == null ? local.deploy_id : var.aurora_identifier
 }
 
 module "network" {
@@ -46,7 +47,8 @@ module "storage" {
 }
 
 locals {
-  create_pg = var.bufstream_metadata == "postgres"
+  create_pg     = var.bufstream_metadata == "postgres"
+  create_aurora = var.bufstream_metadata == "aurora"
 }
 
 module "postgres" {
@@ -62,6 +64,21 @@ module "postgres" {
   postgres_version      = var.postgres_version
   rds_allocated_storage = var.rds_allocated_storage
   postgres_db_name      = var.postgres_db_name
+}
+
+module "aurora" {
+  source = "./metadata/aurora"
+  count  = local.create_aurora ? 1 : 0
+
+  vpc_id                   = var.vpc_id == "" ? module.network.vpc_id : var.vpc_id
+  subnet_ids               = length(var.subnet_ids) == 0 ? module.network.private_subnet_ids : var.subnet_ids
+  aurora_identifier        = local.aurora_id
+  postgres_username        = var.postgres_username
+  aurora_port              = var.aurora_port
+  aurora_instance_class    = var.aurora_instance_class
+  postgres_version         = var.postgres_version
+  postgres_db_name         = var.postgres_db_name
+  availability_zone        = var.availability_zone
 }
 
 # We create this here so we can have the hostname ready for bufstream.
@@ -126,11 +143,24 @@ locals {
     dsn         = module.postgres[0].pg_dsn
     aws_profile = var.profile
   }) : null
+
+  aurora_secret = local.create_aurora ? templatefile("${path.module}/pg-setup.sh.tpl", {
+    region      = var.region
+    secret_arn  = module.aurora[0].pg_pw_secret_arn
+    dsn         = module.aurora[0].pg_dsn
+    aws_profile = var.profile
+  }) : null
 }
 
 resource "local_file" "pg_secret_script" {
   count    = var.generate_config_files_path != null && local.create_pg ? 1 : 0
   content  = local.pg_secret
+  filename = "${var.generate_config_files_path}/aws-pg-setup.sh"
+}
+
+resource "local_file" "aurora_secret_script" {
+  count    = var.generate_config_files_path != null && local.create_aurora ? 1 : 0
+  content  = local.aurora_secret
   filename = "${var.generate_config_files_path}/aws-pg-setup.sh"
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -70,15 +70,17 @@ module "aurora" {
   source = "./metadata/aurora"
   count  = local.create_aurora ? 1 : 0
 
-  vpc_id                   = var.vpc_id == "" ? module.network.vpc_id : var.vpc_id
-  subnet_ids               = length(var.subnet_ids) == 0 ? module.network.private_subnet_ids : var.subnet_ids
-  aurora_identifier        = local.aurora_id
-  postgres_username        = var.postgres_username
-  aurora_port              = var.aurora_port
-  aurora_instance_class    = var.aurora_instance_class
-  postgres_version         = var.postgres_version
-  postgres_db_name         = var.postgres_db_name
-  availability_zone        = var.availability_zone
+  vpc_id                 = var.vpc_id == "" ? module.network.vpc_id : var.vpc_id
+  subnet_ids             = length(var.subnet_ids) == 0 ? module.network.private_subnet_ids : var.subnet_ids
+  aurora_identifier      = local.aurora_id
+  postgres_username      = var.postgres_username
+  aurora_port            = var.aurora_port
+  aurora_instance_class  = var.aurora_instance_class
+  postgres_version       = var.postgres_version
+  postgres_db_name       = var.postgres_db_name
+  availability_zone      = var.availability_zone
+  aws_region             = var.region
+  cluster_instance_count = var.cluster_instance_count
 }
 
 # We create this here so we can have the hostname ready for bufstream.

--- a/aws/metadata/aurora/main.tf
+++ b/aws/metadata/aurora/main.tf
@@ -2,6 +2,21 @@ data "aws_vpc" "buf" {
   id = var.vpc_id
 }
 
+resource "random_string" "aurora_password" {
+  length  = 20
+  special = false
+  upper   = false
+}
+
+resource "aws_secretsmanager_secret" "aurora_pass_secret" {
+  name = "${var.aurora_identifier}-cluster-pass"
+}
+
+resource "aws_secretsmanager_secret_version" "aurora_pass_sv" {
+  secret_id     = aws_secretsmanager_secret.aurora_pass_secret.id
+  secret_string = jsonencode({ "password" = "${random_string.aurora_password.result}" }) # matches 'manage_master_password' format
+}
+
 resource "aws_security_group" "aurora" {
   name   = "${var.aurora_identifier}-aurora-sg"
   vpc_id = var.vpc_id
@@ -24,18 +39,26 @@ resource "aws_db_subnet_group" "aurora" {
   }
 }
 
+data "aws_secretsmanager_secret_version" "db_pass_secret" {
+  secret_id = aws_secretsmanager_secret.aurora_pass_secret.id
+  depends_on = [
+    aws_secretsmanager_secret.aurora_pass_secret,
+    aws_secretsmanager_secret_version.aurora_pass_sv
+  ]
+}
+
 resource "aws_rds_cluster" "bufpg" {
-  cluster_identifier          = "${var.aurora_identifier}-bufstream-aurora"
-  engine                      = "aurora-postgresql"
-  engine_version              = var.postgres_version
-  availability_zones          = [var.availability_zone]
-  master_username             = var.postgres_username
-  port                        = var.aurora_port
-  database_name               = var.postgres_db_name
-  db_subnet_group_name        = aws_db_subnet_group.aurora.name
-  vpc_security_group_ids      = [aws_security_group.aurora.id]
-  manage_master_user_password = true
-  skip_final_snapshot         = true
+  cluster_identifier     = "${var.aurora_identifier}-bufstream-aurora"
+  engine                 = "aurora-postgresql"
+  engine_version         = var.postgres_version
+  availability_zones     = [var.availability_zone]
+  master_username        = var.postgres_username
+  master_password        = jsondecode(data.aws_secretsmanager_secret_version.db_pass_secret.secret_string)["password"]
+  port                   = var.aurora_port
+  database_name          = var.postgres_db_name
+  db_subnet_group_name   = aws_db_subnet_group.aurora.name
+  vpc_security_group_ids = [aws_security_group.aurora.id]
+  skip_final_snapshot    = true
 
   lifecycle {
     ignore_changes = [
@@ -45,7 +68,7 @@ resource "aws_rds_cluster" "bufpg" {
 }
 
 resource "aws_rds_cluster_instance" "bufstream_aurora_instances" {
-  count                = 2
+  count                = var.cluster_instance_count
   availability_zone    = var.availability_zone
   identifier           = "${var.aurora_identifier}-bufstream-aurora-${count.index}"
   cluster_identifier   = aws_rds_cluster.bufpg.id
@@ -54,3 +77,5 @@ resource "aws_rds_cluster_instance" "bufstream_aurora_instances" {
   engine_version       = aws_rds_cluster.bufpg.engine_version
   db_subnet_group_name = aws_db_subnet_group.aurora.name
 }
+
+

--- a/aws/metadata/aurora/main.tf
+++ b/aws/metadata/aurora/main.tf
@@ -14,7 +14,7 @@ resource "aws_secretsmanager_secret" "aurora_pass_secret" {
 
 resource "aws_secretsmanager_secret_version" "aurora_pass_sv" {
   secret_id     = aws_secretsmanager_secret.aurora_pass_secret.id
-  secret_string = jsonencode({ "password" = "${random_string.aurora_password.result}" }) # matches 'manage_master_password' format
+  secret_string = jsonencode({ "password" = random_string.aurora_password.result }) # matches 'manage_master_password' format
 }
 
 resource "aws_security_group" "aurora" {

--- a/aws/metadata/aurora/main.tf
+++ b/aws/metadata/aurora/main.tf
@@ -36,6 +36,12 @@ resource "aws_rds_cluster" "bufpg" {
   vpc_security_group_ids      = [aws_security_group.aurora.id]
   manage_master_user_password = true
   skip_final_snapshot         = true
+
+  lifecycle {
+    ignore_changes = [
+      availability_zones
+    ]
+  }
 }
 
 resource "aws_rds_cluster_instance" "bufstream_aurora_instances" {

--- a/aws/metadata/aurora/main.tf
+++ b/aws/metadata/aurora/main.tf
@@ -27,7 +27,6 @@ resource "aws_security_group" "aurora" {
     protocol    = "tcp"
     cidr_blocks = [data.aws_vpc.buf.cidr_block]
   }
-
 }
 
 resource "aws_db_subnet_group" "aurora" {
@@ -77,5 +76,3 @@ resource "aws_rds_cluster_instance" "bufstream_aurora_instances" {
   engine_version       = aws_rds_cluster.bufpg.engine_version
   db_subnet_group_name = aws_db_subnet_group.aurora.name
 }
-
-

--- a/aws/metadata/aurora/main.tf
+++ b/aws/metadata/aurora/main.tf
@@ -1,0 +1,50 @@
+data "aws_vpc" "buf" {
+  id = var.vpc_id
+}
+
+resource "aws_security_group" "aurora" {
+  name   = "${var.aurora_identifier}-aurora-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    from_port   = var.aurora_port
+    to_port     = var.aurora_port
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.buf.cidr_block]
+  }
+
+}
+
+resource "aws_db_subnet_group" "aurora" {
+  name       = "${var.aurora_identifier}-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.aurora_identifier}-subnet-group"
+  }
+}
+
+resource "aws_rds_cluster" "bufpg" {
+  cluster_identifier          = "${var.aurora_identifier}-bufstream-aurora"
+  engine                      = "aurora-postgresql"
+  engine_version              = var.postgres_version
+  availability_zones          = [var.availability_zone]
+  master_username             = var.postgres_username
+  port                        = var.aurora_port
+  database_name               = var.postgres_db_name
+  db_subnet_group_name        = aws_db_subnet_group.aurora.name
+  vpc_security_group_ids      = [aws_security_group.aurora.id]
+  manage_master_user_password = true
+  skip_final_snapshot         = true
+}
+
+resource "aws_rds_cluster_instance" "bufstream_aurora_instances" {
+  count                = 2
+  availability_zone    = var.availability_zone
+  identifier           = "${var.aurora_identifier}-bufstream-aurora-${count.index}"
+  cluster_identifier   = aws_rds_cluster.bufpg.id
+  instance_class       = var.aurora_instance_class
+  engine               = aws_rds_cluster.bufpg.engine
+  engine_version       = aws_rds_cluster.bufpg.engine_version
+  db_subnet_group_name = aws_db_subnet_group.aurora.name
+}

--- a/aws/metadata/aurora/outputs.tf
+++ b/aws/metadata/aurora/outputs.tf
@@ -1,0 +1,12 @@
+output "pg_dsn" {
+  description = "Partial DSN of the Postgres instance with env placeholder for password"
+
+  value = "postgresql://${aws_rds_cluster.bufpg.master_username}:$PG_PASSWORD@${aws_rds_cluster.bufpg.endpoint}/${aws_rds_cluster.bufpg.database_name}?sslmode=require"
+
+  sensitive = true
+}
+
+output "pg_pw_secret_arn" {
+  description = "The ARN of the secret holding the PG password"
+  value       = aws_rds_cluster.bufpg.master_user_secret[0].secret_arn
+}

--- a/aws/metadata/aurora/outputs.tf
+++ b/aws/metadata/aurora/outputs.tf
@@ -8,5 +8,5 @@ output "pg_dsn" {
 
 output "pg_pw_secret_arn" {
   description = "The ARN of the secret holding the PG password"
-  value       = aws_rds_cluster.bufpg.master_user_secret[0].secret_arn
+  value       = aws_secretsmanager_secret.aurora_pass_secret.arn
 }

--- a/aws/metadata/aurora/variables.tf
+++ b/aws/metadata/aurora/variables.tf
@@ -1,0 +1,49 @@
+variable "vpc_id" {
+  description = "VPC ID of the EKS cluster"
+  type        = string
+}
+
+variable "postgres_username" {
+  description = "Postgres username for aurora instance"
+  type        = string
+  default     = "postgres"
+}
+
+variable "subnet_ids" {
+  description = "IDs of the private subnets for the aurora instance to use"
+  type        = list(string)
+}
+
+variable "aurora_port" {
+  description = "Port number for the aurora instance"
+  type        = number
+  default     = 5432
+}
+
+variable "aurora_instance_class" {
+  description = "aurora instance class to use"
+  type        = string
+  default     = "db.r8g.xlarge"
+}
+
+variable "postgres_version" {
+  description = "Postgres version"
+  type        = string
+  default     = "17"
+}
+
+variable "postgres_db_name" {
+  description = "Name of the database for metadata"
+  type        = string
+  default     = "bufstream"
+}
+
+variable "aurora_identifier" {
+  description = "Identifier of the aurora instance"
+  type        = string
+}
+
+variable "availability_zone" {
+  type    = string
+  default = null
+}

--- a/aws/metadata/aurora/variables.tf
+++ b/aws/metadata/aurora/variables.tf
@@ -9,11 +9,6 @@ variable "cluster_instance_count" {
   default     = 2
 }
 
-variable "aws_region" {
-  description = "region to provision resources"
-  type        = string
-}
-
 variable "postgres_username" {
   description = "Postgres username for aurora instance"
   type        = string

--- a/aws/metadata/aurora/variables.tf
+++ b/aws/metadata/aurora/variables.tf
@@ -3,6 +3,17 @@ variable "vpc_id" {
   type        = string
 }
 
+variable "cluster_instance_count" {
+  description = "number of instances of rds to provision"
+  type        = number
+  default     = 2
+}
+
+variable "aws_region" {
+  description = "region to provision resources"
+  type        = string
+}
+
 variable "postgres_username" {
   description = "Postgres username for aurora instance"
   type        = string

--- a/aws/metadata/aurora/versions.tf
+++ b/aws/metadata/aurora/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.5.0"
+  required_version = "~> 1.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws/metadata/aurora/versions.tf
+++ b/aws/metadata/aurora/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7.2"
+    }
+  }
+}

--- a/aws/network/main.tf
+++ b/aws/network/main.tf
@@ -1,6 +1,6 @@
 locals {
   vpc_id           = var.create_vpc ? aws_vpc.bufstream_vpc[0].id : var.vpc_id
-  azs              = slice(data.aws_availability_zones.available.names, 0, 3)
+  azs              = slice(data.aws_availability_zones.available.names, 0, 2)
   subnet_cidrs     = cidrsubnets(var.vpc_cidr, 5, 5, 5, 5, 5, 5)
   private_az_cidrs = zipmap(local.azs, slice(local.subnet_cidrs, 0, length(local.azs)))
   public_az_cidr   = zipmap(local.azs, slice(local.subnet_cidrs, length(local.azs), length(local.azs) * 2))

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -208,3 +208,9 @@ variable "availability_zone" {
   type        = string
   default     = null
 }
+
+variable "cluster_instance_count" {
+  description = "number of Aurora nodes to provision"
+  type        = number
+  default     = 2
+}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -14,9 +14,9 @@ variable "bufstream_metadata" {
   type        = string
 
   validation {
-    condition = contains(["postgres", "etcd"], var.bufstream_metadata)
+    condition = contains(["postgres", "etcd", "aurora"], var.bufstream_metadata)
 
-    error_message = "must be either 'postgres' or 'etcd'"
+    error_message = "must be either 'postgres', 'aurora', or 'etcd'"
   }
 }
 
@@ -44,6 +44,12 @@ variable "vpc_cidr" {
   description = "CIDR range for the VPC, needs to be able to contain six contiguous /21 subnets. AWS suggests a /19 but most will recommend a /16 to avoid IP exhaustion. https://docs.aws.amazon.com/eks/latest/best-practices/ip-opt.html#_mitigate_ip_exhaustion"
   type        = string
   default     = "10.64.0.0/16"
+}
+
+variable "internal_only_nlb" {
+  description = "toggle public accessibility of nlb on/off"
+  type        = bool
+  default     = true
 }
 
 variable "create_subnets" {
@@ -177,8 +183,28 @@ variable "postgres_db_name" {
   default     = "bufstream"
 }
 
-variable "internal_only_nlb" {
-  description = "toggle public accessibility of nlb on/off"
-  type        = bool
-  default     = true
+### aurora variables. not conendensed with prior to avoid breaking benchmark implementation
+
+variable "aurora_identifier" {
+  description = "Identifier of the Aurora instance"
+  type        = string
+  default     = null
+}
+
+variable "aurora_port" {
+  description = "Port number for the Aurora instance"
+  type        = number
+  default     = 5432
+}
+
+variable "aurora_instance_class" {
+  description = "Aurora instance class to use"
+  type        = string
+  default     = "db.r6gd.xlarge"
+}
+
+variable "availability_zone" {
+  description = "Single AZ used for Aurora"
+  type        = string
+  default     = null
 }

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ if [[ "${BUFSTREAM_TFVARS}" == "" ]] ; then
 fi
 
 case "${BUFSTREAM_METADATA}" in
-"postgres" | "etcd")
+"postgres" | "etcd" | "aurora")
   ;;
 "spanner")
   if [[ "$BUFSTREAM_CLOUD" != "gcp" ]] ; then

--- a/install.sh
+++ b/install.sh
@@ -125,7 +125,7 @@ if [[ "${BUFSTREAM_CLOUD}" == "aws" && -n "${BUFSTREAM_AWS_MIN_NODE_COUNT}" ]] ;
     apply -f -
 fi
 
-if [[ "${BUFSTREAM_METADATA}" == "postgres" ]] ; then
+if [[ "${BUFSTREAM_METADATA}" == "postgres" || "${BUFSTREAM_METADATA}" == "aurora" ]] ; then
   echo "Running Postgres setup script..."
   KUBECONFIG="${CONFIG_GEN_PATH}/kubeconfig.yaml" \
   NAMESPACE="${BUFSTREAM_NAMESPACE:-bufstream}" \


### PR DESCRIPTION
Extends aws support to allow provisioning with AWS aurora. Opening as draft because:
- want to allow customizing node size
- want to add small doc on instance usage
- want to add small note about availability zones