### PR TITLE
Enforce encryption by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ If Aurora is selected for the metadata storage, an AWS Aurora cluster and a Secr
 If using Aurora, be aware that it attempts to use a single AZ for provisioned instances. Most regions follow the convention of `us-east-1` -> `us-east-1a` for region -> az.
 This will default to the first available AZ from the region variable.
 
+Both Aurora and RDS default to encryption being on. This can be turned off with setting `storage_encrypted` to `false`.
+
 Aurora additionally uses the `postgres_username`, `postgres_version` and `postgres_db_name` variables that Postgres uses, which are not required to be set.
 
 Required variables in `tfvars`:

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -64,6 +64,7 @@ module "postgres" {
   postgres_version      = var.postgres_version
   rds_allocated_storage = var.rds_allocated_storage
   postgres_db_name      = var.postgres_db_name
+  storage_encrypted     = var.storage_encrypted
 }
 
 data "aws_availability_zones" "available" {
@@ -85,6 +86,7 @@ module "aurora" {
   availability_zone      = var.availability_zone == null ? data.aws_availability_zones.available.names[0] : var.availability_zone
   aws_region             = var.region
   cluster_instance_count = var.cluster_instance_count
+  storage_encrypted      = var.storage_encrypted
 }
 
 # We create this here so we can have the hostname ready for bufstream.

--- a/aws/metadata/aurora/main.tf
+++ b/aws/metadata/aurora/main.tf
@@ -58,6 +58,7 @@ resource "aws_rds_cluster" "bufpg" {
   db_subnet_group_name   = aws_db_subnet_group.aurora.name
   vpc_security_group_ids = [aws_security_group.aurora.id]
   skip_final_snapshot    = true
+  storage_encrypted      = var.storage_encrypted
 
   lifecycle {
     ignore_changes = [

--- a/aws/metadata/aurora/variables.tf
+++ b/aws/metadata/aurora/variables.tf
@@ -53,3 +53,8 @@ variable "availability_zone" {
   type    = string
   default = null
 }
+
+variable "storage_encrypted" {
+  type    = string
+  default = true
+}

--- a/aws/metadata/postgres/main.tf
+++ b/aws/metadata/postgres/main.tf
@@ -38,5 +38,6 @@ resource "aws_db_instance" "bufpg" {
   availability_zone           = var.availability_zone
   db_subnet_group_name        = aws_db_subnet_group.rds.name
   vpc_security_group_ids      = [aws_security_group.rds.id]
+  storage_encrypted           = var.storage_encrypted
 }
 

--- a/aws/metadata/postgres/variables.tf
+++ b/aws/metadata/postgres/variables.tf
@@ -60,3 +60,8 @@ variable "availability_zone" {
   type    = string
   default = null
 }
+
+variable "storage_encrypted" {
+  type    = string
+  default = true
+}

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -214,3 +214,9 @@ variable "cluster_instance_count" {
   type        = number
   default     = 2
 }
+
+variable "storage_encrypted" {
+  description = "whether to encrypt RDS at rest"
+  type        = string
+  default     = true
+}


### PR DESCRIPTION
turns on encryption for RDS + Aurora by default. adds ability to opt out. adds note to README documenting this.